### PR TITLE
add exports for windows

### DIFF
--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -39,6 +39,7 @@ if(WIN32)
   message("library lib: ${LIBRARY_LIB}")
   
 elseif(UNIX)
+   # this is GCC specific
    set (FLAGS "-O2 -funsigned-char -Wall  -Wl,--no-undefined")  
    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
    set (CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
@@ -58,7 +59,9 @@ add_library(tomobar SHARED
     	    ${CMAKE_CURRENT_SOURCE_DIR}/functions_CPU/utils.c
 	    )
 target_link_libraries(tomobar ${EXTRA_LIBRARIES} )
-include_directories(tomobar PUBLIC 
+target_include_directories(tomobar PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_include_directories(tomobar PUBLIC 
                       ${LIBRARY_INC}/include 
 					  ${CMAKE_CURRENT_SOURCE_DIR}
 		              ${CMAKE_CURRENT_SOURCE_DIR}/functions_CPU/ )

--- a/src/Core/include/RingWeights_core.h
+++ b/src/Core/include/RingWeights_core.h
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include "omp.h"
 #include "utils.h"
-
+#include "dll_export.h"
 
 /*
 * C function to establish a better model for supressing ring artifacts.
@@ -39,14 +39,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-float RingWeights_main(float *residual, float *weights, int window_halfsize_detectors, int window_halfsize_angles, int window_halfsize_projections, long anglesDim, long detectorsDim, long slices);
+DLL_EXPORT float RingWeights_main(float *residual, float *weights, int window_halfsize_detectors, int window_halfsize_angles, int window_halfsize_projections, long anglesDim, long detectorsDim, long slices);
 /************2D functions ***********/
-float RingWeights_det2D(float *residual, float *weights_temp, int window_halfsize_detectors, int detectors_full_window, long anglesDim, long detectorsDim, long i, long j);
-float RingWeights_angles2D(float *weights_temp, float *weights, int window_halfsize_angles, int angles_full_window, long anglesDim, long detectorsDim, long i, long j);
+DLL_EXPORT float RingWeights_det2D(float *residual, float *weights_temp, int window_halfsize_detectors, int detectors_full_window, long anglesDim, long detectorsDim, long i, long j);
+DLL_EXPORT float RingWeights_angles2D(float *weights_temp, float *weights, int window_halfsize_angles, int angles_full_window, long anglesDim, long detectorsDim, long i, long j);
 /************3D functions ***********/
-float RingWeights_proj3D(float *residual, float *weights_temp, int window_halfsize_projections, int projections_full_window, long anglesDim, long detectorsDim, long slices, long j, long i, long k);
-float RingWeights_det3D(float *residual, float *weights_temp, int window_halfsize_detectors, int detectors_full_window, long anglesDim, long detectorsDim, long slices, long j, long i, long k);
-float RingWeights_angles3D(float *weights_temp, float *weights, int window_halfsize_angles, int angles_full_window, long anglesDim, long detectorsDim, long slices, long j, long i, long k);
+DLL_EXPORT float RingWeights_proj3D(float *residual, float *weights_temp, int window_halfsize_projections, int projections_full_window, long anglesDim, long detectorsDim, long slices, long j, long i, long k);
+DLL_EXPORT float RingWeights_det3D(float *residual, float *weights_temp, int window_halfsize_detectors, int detectors_full_window, long anglesDim, long detectorsDim, long slices, long j, long i, long k);
+DLL_EXPORT float RingWeights_angles3D(float *weights_temp, float *weights, int window_halfsize_angles, int angles_full_window, long anglesDim, long detectorsDim, long slices, long j, long i, long k);
 #ifdef __cplusplus
 }
 #endif

--- a/src/Core/include/dll_export.h
+++ b/src/Core/include/dll_export.h
@@ -1,0 +1,38 @@
+/*
+CCP in Tomographic Imaging (CCPi) Core Imaging Library (CIL).
+
+Copyright 2017-2020 UKRI-STFC
+Copyright 2017-2020 University of Manchester
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#pragma once
+#ifndef DLLEXPORT_H
+#define DLLEXPORT_H
+
+#if defined(_WIN32) || defined(__WIN32__)
+#if defined(dll_EXPORTS)  // add by CMake 
+#define  DLL_EXPORT __declspec(dllexport)
+#define EXPIMP_TEMPLATE
+#else
+#define  DLL_EXPORT __declspec(dllimport)
+#define EXPIMP_TEMPLATE extern
+#endif 
+#elif defined(linux) || defined(__linux) || defined(__APPLE__)
+#define DLL_EXPORT
+#ifndef __cdecl
+#define __cdecl
+#endif
+#endif
+
+#endif

--- a/src/Core/include/utils.h
+++ b/src/Core/include/utils.h
@@ -15,11 +15,13 @@ limitations under the License.
 #include <stdlib.h>
 #include <memory.h>
 #include "omp.h"
+#include "dll_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-float copyIm(float *A, float *U, long dimX, long dimY, long dimZ);
-unsigned char copyIm_unchar(unsigned char *A, unsigned char *U, int dimX, int dimY, int dimZ);
+DLL_EXPORT float copyIm(float *A, float *U, long dimX, long dimY, long dimZ);
+DLL_EXPORT unsigned char copyIm_unchar(unsigned char *A, unsigned char *U, int dimX, int dimY, int dimZ);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Adds machinery to be able to export code for the windows system.

Minor restructuring of the `src/Core` which separates `includes` in a specific directory.