### PR TITLE
Opimises fourier inverse method and adds performance test

### DIFF
--- a/tomobar/cuda_kernels/fft_us_kernels.cu
+++ b/tomobar/cuda_kernels/fft_us_kernels.cu
@@ -28,6 +28,10 @@ extern "C" __global__ void gather_kernel(float2 *g, float2 *f, float *theta, int
     y0 = 0.5f - 1e-5;
   g0.x = g[g_ind].x;
   g0.y = g[g_ind].y;
+  // offset f by [tz, n+m, n+m]
+  int stride1 = 2*n + 2*m;
+  int stride2 = stride1 * stride1;
+  f += n+m + (n+m) * stride1 + tz * stride2;
   for (int i1 = 0; i1 < 2 * m + 1; i1++)
   {
     ell1 = floorf(2 * n * y0) - m + i1;
@@ -39,7 +43,7 @@ extern "C" __global__ void gather_kernel(float2 *g, float2 *f, float *theta, int
       w = coeff0 * __expf(coeff1 * (w0 * w0 + w1 * w1));
       g0t.x = w*g0.x;
       g0t.y = w*g0.y;
-      f_ind = n + m + ell0 + (2 * n + 2 * m) * (n + m + ell1) + tz * (2 * n + 2 * m) * (2 * n + 2 * m);
+      f_ind = ell0 + stride1 * ell1 ;
       atomicAdd(&(f[f_ind].x), g0t.x);
       atomicAdd(&(f[f_ind].y), g0t.y);
     }

--- a/tomobar/fourier.py
+++ b/tomobar/fourier.py
@@ -5,6 +5,7 @@ https://tomocupy.readthedocs.io/en/latest/
 """
 
 nocupy = False
+import numpy as np
 try:
     import cupy as xp
     from cupyx import scipy
@@ -74,23 +75,23 @@ def _filtersinc3D_cupy(projection3D: xp.ndarray, cutoff: float = 0.6) -> xp.ndar
 
 def _wint(n, t):
     N = len(t)
-    s = xp.linspace(1e-40, 1, n)
+    s = np.linspace(1e-40, 1, n)
     # Inverse vandermonde matrix
-    tmp1 = xp.arange(n)
-    tmp2 = xp.arange(1, n + 2)
-    iv = xp.linalg.inv(xp.exp(xp.outer(tmp1, xp.log(s))))
-    u = xp.diff(
-        xp.exp(xp.outer(tmp2, xp.log(s))) * xp.tile(1.0 / tmp2[..., xp.newaxis], [1, n])
+    tmp1 = np.arange(n)
+    tmp2 = np.arange(1, n + 2)
+    iv = np.linalg.inv(np.exp(np.outer(tmp1, np.log(s))))
+    u = np.diff(
+        np.exp(np.outer(tmp2, np.log(s))) * np.tile(1.0 / tmp2[..., np.newaxis], [1, n])
     )  # integration over short intervals
-    W1 = xp.matmul(iv, u[1 : n + 1, :])  # x*pn(x) term
-    W2 = xp.matmul(iv, u[0:n, :])  # const*pn(x) term
+    W1 = np.matmul(iv, u[1 : n + 1, :])  # x*pn(x) term
+    W2 = np.matmul(iv, u[0:n, :])  # const*pn(x) term
 
     # Compensate for overlapping short intervals
-    tmp1 = xp.arange(1, n)
-    tmp2 = (n - 1) * xp.ones((N - 2 * (n - 1) - 1))
-    tmp3 = xp.arange(n - 1, 0, -1)
-    p = 1 / xp.concatenate((tmp1, tmp2, tmp3))
-    w = xp.zeros(N)
+    tmp1 = np.arange(1, n)
+    tmp2 = (n - 1) * np.ones((N - 2 * (n - 1) - 1))
+    tmp3 = np.arange(n - 1, 0, -1)
+    p = 1 / np.concatenate((tmp1, tmp2, tmp3))
+    w = np.zeros(N)
     for j in range(N - n + 1):
         # Change coordinates, and constant and linear parts
         W = ((t[j + n - 1] - t[j]) ** 2) * W1 + (t[j + n - 1] - t[j]) * t[j] * W2
@@ -99,14 +100,15 @@ def _wint(n, t):
             w[j : j + n] = w[j : j + n] + p[j + k] * W[:, k]
 
     wn = w
-    wn[-40:] = (w[-40]) / (N - 40) * xp.arange(N - 40, N)
+    wn[-40:] = (w[-40]) / (N - 40) * np.arange(N - 40, N)
+    
     return wn
 
 
 def calc_filter(n, filter):
     """fbp filters, higher order integrals discretization"""
     d = 0.5
-    t = xp.arange(0, n / 2 + 1) / n
+    t = np.arange(0, n / 2 + 1) / n
 
     if filter == "none":
         wfa = n * 0.5 + t * 0
@@ -115,25 +117,25 @@ def calc_filter(n, filter):
         # .*(t/(2*d)<=1)%compute the weigths
         wfa = n * 0.5 * _wint(12, t)
     elif filter == "shepp":
-        wfa = n * 0.5 * _wint(12, t) * xp.sinc(t / (2 * d)) * (t / d <= 2)
+        wfa = n * 0.5 * _wint(12, t) * np.sinc(t / (2 * d)) * (t / d <= 2)
     elif filter == "cosine":
-        wfa = n * 0.5 * _wint(12, t) * xp.cos(xp.pi * t / (2 * d)) * (t / d <= 1)
+        wfa = n * 0.5 * _wint(12, t) * np.cos(np.pi * t / (2 * d)) * (t / d <= 1)
     elif filter == "cosine2":
-        wfa = n * 0.5 * _wint(12, t) * (xp.cos(xp.pi * t / (2 * d))) ** 2 * (t / d <= 1)
+        wfa = n * 0.5 * _wint(12, t) * (np.cos(np.pi * t / (2 * d))) ** 2 * (t / d <= 1)
     elif filter == "hamming":
         wfa = (
             n
             * 0.5
             * _wint(12, t)
-            * (0.54 + 0.46 * xp.cos(xp.pi * t / d))
+            * (0.54 + 0.46 * np.cos(np.pi * t / d))
             * (t / d <= 1)
         )
     elif filter == "hann":
-        wfa = n * 0.5 * _wint(12, t) * (1 + xp.cos(xp.pi * t / d)) / 2.0 * (t / d <= 1)
+        wfa = n * 0.5 * _wint(12, t) * (1 + np.cos(np.pi * t / d)) / 2.0 * (t / d <= 1)
     elif filter == "parzen":
         wfa = n * 0.5 * _wint(12, t) * pow(1 - t / d, 3) * (t / d <= 1)
 
     wfa = 2 * wfa * (wfa >= 0)
     wfa[0] *= 2
-    wfa = wfa.astype("float32")
+    wfa = xp.asarray(wfa, dtype=xp.float32)
     return wfa


### PR DESCRIPTION
These are a few optimisations to speed up the Fourier method. On a V100, this reduces the runtime from approximately 2.8s to 400ms (6x speedup). The main jump in performance comes from computing the `_wint` filter function on the CPU, and various optimisations to avoid small scalar operations on GPU.

Further optimisations are likely possible in the `gather_kernel` - avoiding atomics either by:
- using shared memory and collaborate between threads in a thread block to avoid atomic adds, and then use one atomic add per item/thread block to write it back to global memory
- re-think the thread allocation and do it based on the output index - have 1 thread per output index and have it gather all the inputs that need to be added to that index. This avoids `atomicAdd` completely.
