### PR TITLE
FFT plans flushing in FBP filtering

### DIFF
--- a/tests/test_RecToolsDIRCuPy.py
+++ b/tests/test_RecToolsDIRCuPy.py
@@ -183,6 +183,31 @@ def test_FBP3D(data_cupy, angles, ensure_clean_memory):
     assert recon_data.shape == (128, 160, 160)
 
 
+# @pytest.mark.parametrize("projections", [1801, 3601])
+# @pytest.mark.parametrize("slices", [3, 5, 7, 11])
+# @pytest.mark.parametrize("recon_size_it", [1200, 2560])
+# def test_FBP3D_bigdata(slices, recon_size_it, projections, ensure_clean_memory):
+#     data = cp.random.random_sample((projections, slices, 2560), dtype=np.float32)
+#     angles = np.linspace(0.0 * np.pi / 180.0, 180.0 * np.pi / 180.0, data.shape[0])
+#     detX = cp.shape(data)[2]
+#     detY = cp.shape(data)[1]
+#     N_size = detX
+#     RecToolsCP = RecToolsDIRCuPy(
+#         DetectorsDimH=detX,  # Horizontal detector dimension
+#         DetectorsDimV=detY,  # Vertical detector dimension (3D case)
+#         CenterRotOffset=0.0,  # Center of Rotation scalar or a vector
+#         AnglesVec=angles,  # A vector of projection angles in radians
+#         ObjSize=N_size,  # Reconstructed object dimensions (scalar)
+#         device_projector="gpu",
+#     )
+#     FBPrec_cupy = RecToolsCP.FBP(
+#         data,
+#         data_axes_labels_order=["angles", "detY", "detX"],
+#         cutoff_freq=1.1,
+#     )
+#     recon_data = FBPrec_cupy.get()
+
+
 def test_FBP3D_mask(data_cupy, angles, ensure_clean_memory):
     detX = cp.shape(data_cupy)[2]
     detY = cp.shape(data_cupy)[1]

--- a/tomobar/astra_wrappers/astra_base.py
+++ b/tomobar/astra_wrappers/astra_base.py
@@ -521,7 +521,8 @@ class AstraBase:
             proj_id = astra.data3d.link("-proj3d", self.proj_geom, proj_link)
 
         # create a CuPy array with ASTRA link to it
-        recon_volume = xp.zeros(astra.geom_size(self.vol_geom), dtype=np.float32)
+        recon_volume = xp.empty(astra.geom_size(self.vol_geom), dtype=xp.float32)
+
         rec_link = astra.data3d.GPULink(
             recon_volume.data.ptr, *recon_volume.shape[::-1], 4 * recon_volume.shape[2]
         )
@@ -541,6 +542,7 @@ class AstraBase:
         astra.algorithm.delete(alg_id)
         astra.data3d.delete(rec_id)
         astra.data3d.delete(proj_id)
+        del proj_data
         return recon_volume
 
     def runAstraProj3DCuPy(
@@ -563,7 +565,7 @@ class AstraBase:
 
         if self.ordsub_number != 1:
             # ordered-subsets approach
-            proj_volume = xp.zeros(
+            proj_volume = xp.empty(
                 astra.geom_size(self.proj_geom_OS[os_index]), dtype=xp.float32
             )
             gpu_link_sino = astra.data3d.GPULink(
@@ -575,7 +577,7 @@ class AstraBase:
         else:
             # traditional full data parallel beam projection geometry
             # Enabling GPUlink to the created empty CuPy array
-            proj_volume = xp.zeros(astra.geom_size(self.proj_geom), dtype=xp.float32)
+            proj_volume = xp.empty(astra.geom_size(self.proj_geom), dtype=xp.float32)
             gpu_link_sino = astra.data3d.GPULink(
                 proj_volume.data.ptr, *proj_volume.shape[::-1], 4 * proj_volume.shape[2]
             )

--- a/tomobar/methodsDIR_CuPy.py
+++ b/tomobar/methodsDIR_CuPy.py
@@ -129,11 +129,10 @@ class RecToolsDIRCuPy(RecToolsDIR):
 
         # filter the data on the GPU and keep the result there
         data = _filtersinc3D_cupy(data, cutoff=cutoff_freq)
-        xp._default_memory_pool.free_all_blocks()
-        cache = xp.fft.config.get_plan_cache()
-        cache.clear()  # flush FFT cache here before backprojection operation
         data = xp.ascontiguousarray(xp.swapaxes(data, 0, 1))
         reconstruction = self.Atools._backprojCuPy(data)  # 3d backprojecting
+        cache = xp.fft.config.get_plan_cache()
+        cache.clear()  # flush FFT cache here before performing ifft to save the memory
         xp._default_memory_pool.free_all_blocks()
         return _check_kwargs(reconstruction, **kwargs)
 


### PR DESCRIPTION
fixes to reduce memory consumption by removing plans after fft and ifft in FBP 3D