### PR TITLE
Fix filtersinc memory leak

### DIFF
--- a/tomobar/fourier.py
+++ b/tomobar/fourier.py
@@ -46,6 +46,7 @@ def _filtersinc3D_cupy(projection3D: xp.ndarray, cutoff: float = 0.6) -> xp.ndar
     proj_f = scipy.fft.rfft(projection3D, axis=-1, norm="backward", overwrite_x=True)
     cache = xp.fft.config.get_plan_cache()
     cache.clear()  # flush FFT cache here before performing ifft to save the memory
+    xp._default_memory_pool.free_all_blocks()
 
     # generating the filter here so we can schedule/allocate while FFT is keeping the GPU busy
     f = xp.empty((1, 1, DetectorsLengthH // 2 + 1), dtype=xp.float32)
@@ -72,6 +73,7 @@ def _filtersinc3D_cupy(projection3D: xp.ndarray, cutoff: float = 0.6) -> xp.ndar
     )
     cache = xp.fft.config.get_plan_cache()
     cache.clear()
+    xp._default_memory_pool.free_all_blocks()
 
     return projection3D
 

--- a/tomobar/methodsDIR_CuPy.py
+++ b/tomobar/methodsDIR_CuPy.py
@@ -130,6 +130,7 @@ class RecToolsDIRCuPy(RecToolsDIR):
         # filter the data on the GPU and keep the result there
         data = _filtersinc3D_cupy(data, cutoff=cutoff_freq)
         data = xp.ascontiguousarray(xp.swapaxes(data, 0, 1))
+        xp._default_memory_pool.free_all_blocks() # free everything related to the filtering before starting Astra
         reconstruction = self.Atools._backprojCuPy(data)  # 3d backprojecting
         cache = xp.fft.config.get_plan_cache()
         cache.clear()  # flush FFT cache here before performing ifft to save the memory


### PR DESCRIPTION
This PR fixes memory leak in `FBP` and `_filtersinc3D_cupy`:

- after clearing the fft plan cache, the pool needs to be freed to actually clear the used GPU memory
- before passing the contiguous array to ASTRA, the pool again needs to be freed to ensure garbage-collected `proj_f` from `_filtersinc3D_cupy` is free