### PR TITLE
Recon array cropping/padding to deal with even and odd recon sizes in LogPolar

### DIFF
--- a/tests/test_RecToolsDIRCuPy.py
+++ b/tests/test_RecToolsDIRCuPy.py
@@ -157,7 +157,7 @@ def test_Fourier3D_inv(data_cupy, angles, ensure_clean_memory):
     assert recon_data.shape == (128, 160, 160)
 
 
-def test_Fourier3D_Y_odd(ensure_clean_memory):
+def test_Fourier3D_Y_odd_to_even(ensure_clean_memory):
     dev = cp.cuda.Device()
     data_host = np.random.randint(
         low=7515, high=37624, size=(901, 3, 1341), dtype=np.uint16
@@ -182,7 +182,7 @@ def test_Fourier3D_Y_odd(ensure_clean_memory):
     assert recon.shape == (3, N_size, N_size)
 
 
-def test_Fourier3D_Z_odd(ensure_clean_memory):
+def test_Fourier3D_Y_even_to_odd(ensure_clean_memory):
     dev = cp.cuda.Device()
     data_host = np.random.randint(
         low=7515, high=37624, size=(901, 3, 1342), dtype=np.uint16
@@ -191,7 +191,57 @@ def test_Fourier3D_Z_odd(ensure_clean_memory):
     detX = cp.shape(data)[2]
     detY = cp.shape(data)[1]
     angles = np.linspace(0, math.pi, data.shape[0])
-    N_size = 1300
+    N_size = 1333
+    RecToolsCP = RecToolsDIRCuPy(
+        DetectorsDimH=detX,  # Horizontal detector dimension
+        DetectorsDimV=detY,  # Vertical detector dimension (3D case)
+        CenterRotOffset=0.0,  # Center of Rotation scalar or a vector
+        AnglesVec=angles,  # A vector of projection angles in radians
+        ObjSize=N_size,  # Reconstructed object dimensions (scalar)
+        device_projector="gpu",
+    )
+    recon = RecToolsCP.FOURIER_INV(
+        data, data_axes_labels_order=["angles", "detY", "detX"]
+    )
+    assert recon.dtype == np.float32
+    assert recon.shape == (3, N_size, N_size)
+
+
+def test_Fourier3D_Y_even_to_even(ensure_clean_memory):
+    dev = cp.cuda.Device()
+    data_host = np.random.randint(
+        low=7515, high=37624, size=(901, 3, 1342), dtype=np.uint16
+    ).astype(np.float32)
+    data = cp.asarray(data_host)
+    detX = cp.shape(data)[2]
+    detY = cp.shape(data)[1]
+    angles = np.linspace(0, math.pi, data.shape[0])
+    N_size = 1340
+    RecToolsCP = RecToolsDIRCuPy(
+        DetectorsDimH=detX,  # Horizontal detector dimension
+        DetectorsDimV=detY,  # Vertical detector dimension (3D case)
+        CenterRotOffset=0.0,  # Center of Rotation scalar or a vector
+        AnglesVec=angles,  # A vector of projection angles in radians
+        ObjSize=N_size,  # Reconstructed object dimensions (scalar)
+        device_projector="gpu",
+    )
+    recon = RecToolsCP.FOURIER_INV(
+        data, data_axes_labels_order=["angles", "detY", "detX"]
+    )
+    assert recon.dtype == np.float32
+    assert recon.shape == (3, N_size, N_size)
+
+
+def test_Fourier3D_Y_odd_to_odd(ensure_clean_memory):
+    dev = cp.cuda.Device()
+    data_host = np.random.randint(
+        low=7515, high=37624, size=(901, 3, 1341), dtype=np.uint16
+    ).astype(np.float32)
+    data = cp.asarray(data_host)
+    detX = cp.shape(data)[2]
+    detY = cp.shape(data)[1]
+    angles = np.linspace(0, math.pi, data.shape[0])
+    N_size = 1331
     RecToolsCP = RecToolsDIRCuPy(
         DetectorsDimH=detX,  # Horizontal detector dimension
         DetectorsDimV=detY,  # Vertical detector dimension (3D case)


### PR DESCRIPTION
added tests to ensure the odd and even cropping working for logpolar