### PR TITLE
Iterative methods CuPy fixes and a new feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+All notable changes in ToMoBAR project will be documented in this file.
+
+## v.2025.10
+
+### Changed
+`DetectorsDimH_pad` parameter works now in CuPy iterative methods available in `RecToolsIRCuPy` class.
+This allows reconstructing without artifacts on the edges of the reconstruction grid. Especially useful for
+reconstructing data that is larger than the field of view.
+
+### Fixed
+SIRT CuPy algorithm has been fixed.
+
+### New
+FISTA iterative method in `RecToolsIRCuPy` dropped its dependency on Regularisation Toolkit. Currently two regularisers
+available to use: `PD_TV` and `ROF_TV` and they were accelerated and optimised. Therefore FISTA with CuPy is up to 3 times faster compared
+to the previous version and potentially a magnitude faster compared to FISTA in `RecToolsIR`.
+
+## v.2025.08
+
+### Changed
+- $\sf\color{red}Breaking$ $\sf\color{red}changes!$ The API for initializing geometry in both direct and iterative methods (the `RecTools` class) has been updated. A new parameter, `DetectorsDimH_pad`, has been [introduced](https://dkazanc.github.io/ToMoBAR/api/tomobar.methodsDIR.html) to control edge padding along the detector's horizontal dimension. This parameter can help reduce circular/arc [artifacts](https://dkazanc.github.io/ToMoBAR/tutorials/real_data_recon.html) in reconstructions, such as saturated circles or arcs. See updated [Tutorials](https://dkazanc.github.io/ToMoBAR/tutorials/direct_recon.html) and [Demos](https://github.com/dkazanc/ToMoBAR/tree/master/Demos/Python).
+- Log-Polar method (`FOURIER_INV` in `RecToolsDIRCuPy`) has been further accelerated and it is significantly faster FBP.
+

--- a/Demos/Python/Demo_RealDataCuPy.py
+++ b/Demos/Python/Demo_RealDataCuPy.py
@@ -46,7 +46,7 @@ print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
 
 RecToolsCP = RecToolsDIRCuPy(
     DetectorsDimH=detectorHoriz,  # Horizontal detector dimension
-    DetectorsDimH_pad=0,  # Padding size of horizontal detector
+    DetectorsDimH_pad=200,  # Padding size of horizontal detector
     DetectorsDimV=detectorVert,  # Vertical detector dimension (3D case)
     CenterRotOffset=None,  # Centre of Rotation scalar
     AnglesVec=angles_rad,  # A vector of projection angles in radians
@@ -81,6 +81,58 @@ RectoolsCuPy = RecToolsIRCuPy(
 )
 # %%
 print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
+print("%%%%%%%%%%%%Reconstructing with CGLS method %%%%%%%%%%%%%%%%")
+print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
+####################### Creating the data dictionary: #######################
+_data_ = {
+    "projection_norm_data": cp.asarray(
+        data_norm[:, :, 5:10]
+    ),  # Normalised projection data
+    "data_axes_labels_order": data_labels3D,
+}
+
+####################### Creating the algorithm dictionary: #######################
+_algorithm_ = {
+    "iterations": 20,
+    "recon_mask_radius": 2.0,
+}  # The number of iterations
+
+
+# RUN CGLS METHOD:
+Rec_CGLS = RectoolsCuPy.CGLS(_data_, _algorithm_)
+
+fig = plt.figure()
+plt.imshow(cp.asnumpy((Rec_CGLS[3, :, :])), vmin=0, vmax=0.003, cmap="gray")
+plt.title("CGLS reconstruction")
+plt.show()
+# %%
+print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
+print("%%%%%%%%%%%%Reconstructing with SIRT method %%%%%%%%%%%%%%%%")
+print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
+####################### Creating the data dictionary: #######################
+_data_ = {
+    "projection_norm_data": cp.asarray(
+        data_norm[:, :, 5:10]
+    ),  # Normalised projection data
+    "data_axes_labels_order": data_labels3D,
+}
+
+####################### Creating the algorithm dictionary: #######################
+_algorithm_ = {
+    "iterations": 400,
+    "recon_mask_radius": 2.0,
+}  # The number of iterations
+
+
+# RUN SIRT METHOD:
+Rec_SIRT = RectoolsCuPy.SIRT(_data_, _algorithm_)
+
+fig = plt.figure()
+plt.imshow(cp.asnumpy((Rec_SIRT[3, :, :])), vmin=0, vmax=0.003, cmap="gray")
+plt.title("SIRT reconstruction")
+plt.show()
+# %%
+print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
 print("Reconstructing with FISTA OS-TV (PD) method %%%%%%%%%%%%%%%%")
 print("%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%")
 ####################### Creating the data dictionary: #######################
@@ -96,15 +148,16 @@ lc = RectoolsCuPy.powermethod(_data_)  # calculate Lipschitz constant (run once)
 
 ####################### Creating the algorithm dictionary: #######################
 _algorithm_ = {
-    "iterations": 25,
+    "iterations": 15,
     "lipschitz_const": lc.get(),
+    "recon_mask_radius": 2.0,
 }  # The number of iterations
 
 ##### creating regularisation dictionary: #####
 _regularisation_ = {
     "method": "PD_TV",  # Selected regularisation method
     "regul_param": 0.000002,  # Regularisation parameter
-    "iterations": 60,  # The number of regularisation iterations
+    "iterations": 50,  # The number of regularisation iterations
     "half_precision": True,  # enabling half-precision calculation
 }
 
@@ -137,6 +190,7 @@ lc = RectoolsCuPy.powermethod(_data_)  # calculate Lipschitz constant (run once)
 _algorithm_ = {
     "iterations": 25,
     "lipschitz_const": lc.get(),
+    "recon_mask_radius": 0.95,
 }  # The number of iterations
 
 ##### creating regularisation dictionary  #####

--- a/Readme.md
+++ b/Readme.md
@@ -16,9 +16,11 @@
 |--------|-------------------|
 | ![Github Actions](https://github.com/dkazanc/ToMoBAR/actions/workflows/tomobar_conda_upload.yml/badge.svg) | ![conda version](https://anaconda.org/httomo/tomobar/badges/version.svg) ![conda last release](https://anaconda.org/httomo/tomobar/badges/latest_release_date.svg) [![conda platforms](https://anaconda.org/httomo/tomobar/badges/platforms.svg) ![conda dowloads](https://anaconda.org/httomo/tomobar/badges/downloads.svg)](https://anaconda.org/httomo/tomobar/) |
 
-### NEW in ToMoBAR v.2025.08:
-- $\sf\color{red}Breaking$ $\sf\color{red}changes!$ The API for initializing geometry in both direct and iterative methods (the `RecTools` class) has been updated. A new parameter, `DetectorsDimH_pad`, has been [introduced](https://dkazanc.github.io/ToMoBAR/api/tomobar.methodsDIR.html) to control edge padding along the detector's horizontal dimension. This parameter can help reduce circular/arc [artifacts](https://dkazanc.github.io/ToMoBAR/tutorials/real_data_recon.html) in reconstructions, such as saturated circles or arcs. See updated [Tutorials](https://dkazanc.github.io/ToMoBAR/tutorials/direct_recon.html) and [Demos](https://github.com/dkazanc/ToMoBAR/tree/master/Demos/Python).
-- Log-Polar method (`FOURIER_INV` in `RecToolsDIRCuPy`) has been further accelerated and it is significantly faster FBP.
+###
+See [CHANGELOG](https://github.com/dkazanc/ToMoBAR/CHANGELOG.md) for all the changes.
+
+There are $\sf\color{red}breaking$ $\sf\color{red}changes from ToMoBAR v.2025.08!$ The API for initializing geometry in both direct and iterative methods (the `RecTools` class) has been updated. A new parameter, `DetectorsDimH_pad`, has been [introduced](https://dkazanc.github.io/ToMoBAR/api/tomobar.methodsDIR.html) to control edge padding along the detector's horizontal dimension. This parameter can help reduce circular/arc [artifacts](https://dkazanc.github.io/ToMoBAR/tutorials/real_data_recon.html) in reconstructions, such as saturated circles or arcs. See updated [Tutorials](https://dkazanc.github.io/ToMoBAR/tutorials/direct_recon.html) and [Demos](https://github.com/dkazanc/ToMoBAR/tree/master/Demos/Python).
+
 
 ## ToMoBAR highlights:
 Check what ToMoBAR can [do](https://dkazanc.github.io/ToMoBAR/introduction/about.html#what-tomobar-can-do). Please also see [Tutorials](https://dkazanc.github.io/ToMoBAR/tutorials/direct_recon.html) and [Demos](https://github.com/dkazanc/ToMoBAR/tree/master/Demos/Python).

--- a/tomobar/astra_wrappers/astra_tools2d.py
+++ b/tomobar/astra_wrappers/astra_tools2d.py
@@ -67,11 +67,19 @@ class AstraTools2D(AstraBase):
             astra_method = "FP"
         return super()._runAstraProj2D(image, None, astra_method)
 
+    def _forwprojCuPy(self, image: np.ndarray) -> np.ndarray:
+        # TODO: CuPy 2D forward projection is not implemented yet
+        return super()._runAstraProj2D(image, None, "FP_CUDA")
+
     def _forwprojOS(self, image: np.ndarray, os_index: int) -> np.ndarray:
         astra_method = "FP_CUDA"  # 2d forward projection
         if self.processing_arch == "cpu":
             astra_method = "FP"
         return super()._runAstraProj2D(image, os_index, astra_method)
+
+    def _forwprojOSCuPy(self, image: np.ndarray, os_index: int) -> np.ndarray:
+        # TODO: CuPy 2D forward projection is not implemented yet
+        return super()._runAstraProj2D(image, os_index, "FP_CUDA")
 
     def _backproj(self, sinogram: np.ndarray) -> np.ndarray:
         astra_method = "BP_CUDA"  # 2D back projection
@@ -79,11 +87,19 @@ class AstraTools2D(AstraBase):
             astra_method = "BP"
         return super()._runAstraBackproj2D(sinogram, astra_method, 1, None)
 
+    def _backprojCuPy(self, sinogram: np.ndarray) -> np.ndarray:
+        # TODO: CuPy 2D backprojection is not implemented yet
+        return super()._runAstraBackproj2D(sinogram, "BP_CUDA", 1, None)
+
     def _backprojOS(self, sinogram: np.ndarray, os_index: int) -> np.ndarray:
         astra_method = "BP_CUDA"  # 2D back projection
         if self.processing_arch == "cpu":
             astra_method = "BP"
         return super()._runAstraBackproj2D(sinogram, astra_method, 1, os_index)
+
+    def _backprojOSCuPy(self, sinogram: np.ndarray, os_index: int) -> np.ndarray:
+        # TODO: CuPy 2D backprojection is not implemented yet
+        return super()._runAstraBackproj2D(sinogram, "BP_CUDA", 1, os_index)
 
     def _fbp(self, sinogram: np.ndarray) -> np.ndarray:
         astra_method = "FBP_CUDA"  # 2D FBP reconstruction

--- a/tomobar/methodsDIR_CuPy.py
+++ b/tomobar/methodsDIR_CuPy.py
@@ -34,7 +34,7 @@ class RecToolsDIRCuPy(RecToolsDIR):
 
     Args:
         DetectorsDimH (int): Horizontal detector dimension.
-        DetectorsDimH_pad (int): Padding size of horizontal detector
+        DetectorsDimH_pad (int): The amount of padding for the horizontal detector.
         DetectorsDimV (int): Vertical detector dimension for 3D case, 0 or None for 2D case.
         CenterRotOffset (float, ndarray): The Centre of Rotation (CoR) scalar or a vector for each angle.
         AnglesVec (np.ndarray): Vector of projection angles in radians.

--- a/tomobar/supp/dicts.py
+++ b/tomobar/supp/dicts.py
@@ -5,17 +5,6 @@ from tomobar.astra_wrappers.astra_tools3d import AstraTools3D
 from typing import Union
 from tomobar.supp.funcs import _data_dims_swapper
 
-try:
-    import cupy as xp
-
-    try:
-        xp.cuda.Device(0).compute_capability
-        gpu_enabled = True  # CuPy is installed and GPU is available
-    except xp.cuda.runtime.CUDARuntimeError:
-        import numpy as xp
-except ImportError:
-    import numpy as xp
-
 
 def dicts_check(
     self,

--- a/tomobar/supp/suppTools.py
+++ b/tomobar/supp/suppTools.py
@@ -396,6 +396,25 @@ def apply_circular_mask(data, recon_mask_radius, cupyrun=False):
     return data
 
 
+def perform_recon_crop(data, croped_size):
+    """Perform croipping of the larger 3D data array (reconstruction) to a smaller one defined by croped_size
+
+    Args:
+        data (cp.ndarray): 3D CuPy array [vertical, reconX, reconY] to crop
+        croped_size (int): the size of the array after cropping
+
+    Returns:
+        cp.ndarry: cropped CuPy 3D array [vertical, reconX_new_size, reconY_new_size]
+    """
+
+    axis = 2  # or 1
+    original_recon_size = data.shape[axis]
+    crop_limit_start = (original_recon_size - croped_size) // 2
+    crop_limit_stop = croped_size + crop_limit_start
+
+    return data[:, crop_limit_start:crop_limit_stop, crop_limit_start:crop_limit_stop]
+
+
 def _apply_horiz_detector_padding(data, detector_width_pad, cupyrun):
     """extending the size of the horizontal detector, here
     assuming the order of the 3D data as: ["detY", "angles", "detX"] and


### PR DESCRIPTION
Changes to allow iterative CuPy-based methods to work with the horizontal detector padding. 
No padding for CGLS
<img width="987" height="877" alt="image" src="https://github.com/user-attachments/assets/f35eee47-d24e-4ac2-925d-7cd097c14726" />
Padding enabled for CGLS
<img width="987" height="877" alt="image" src="https://github.com/user-attachments/assets/4dc72dae-1b80-48cc-a112-623e2d7cbe58" />
